### PR TITLE
Show the advanced settings if they exist

### DIFF
--- a/src/main/resources/hudson/tasks/Ant/config.groovy
+++ b/src/main/resources/hudson/tasks/Ant/config.groovy
@@ -39,7 +39,7 @@ f.entry(title:_("Targets"),field:"targets") {
     f.expandableTextbox()
 }
 
-f.advanced {
+def advancedEntries = {
     f.entry(title:_("Build File"),field:"buildFile") {
         f.expandableTextbox()
     }
@@ -49,4 +49,10 @@ f.advanced {
     f.entry(title:_("Java Options"),field:"antOpts") {
         f.expandableTextbox()
     }
+}
+if(instance.properties || instance.buildFile || instance.antOpts) {
+  advancedEntries()
+}
+else {
+  f.advanced(advancedEntries)
 }


### PR DESCRIPTION
When troubleshooting builds, it's really annoying to find out that a hidden "advanced" setting was messing things up. This shows the advanced fields for Ant projects that have such settings.

I freely admit that I don't know if this is idiomatic jenkins plugin writing, but this issue has annoyed me so many times that I thought I'd send in a pull request to see what happens.

Let me know if you want the change written differently.
