### PR TITLE
Updated maven-hpi-plugin version to 1.96 and set system property "hudson.bundled.plugins"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,12 @@
       <plugin>
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
-        <version>1.76</version>
+        <version>1.96</version>
         <configuration>
           <dependencyResolution>compile</dependencyResolution>
+          <systemProperties>
+            <hudson.bundled.plugins>${basedir}/work/plugins/ant.hpl</hudson.bundled.plugins>
+          </systemProperties>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
... to be able to use the Ant plugin compiled from
source instead of the one bundled in the Jenkins war file (solution
copied over from subversion-plugin).
