### PR TITLE
Handle expandableTextboxes better for ant properties and ant_opts.

### DIFF
--- a/src/main/java/hudson/tasks/Ant.java
+++ b/src/main/java/hudson/tasks/Ant.java
@@ -190,14 +190,21 @@ public class Ant extends Builder {
 
         args.addKeyValuePairs("-D",build.getBuildVariables(),sensitiveVars);
 
-        args.addKeyValuePairsFromPropertyString("-D",properties,vr,sensitiveVars);
+        //[cs] to support expandableTextboxes, single-liner properties need to be converted into
+        // newline separated properties.
+        String properties2 = properties;
+        if (!properties.contains("\n")) {
+        	properties2 = properties.replaceAll(" +", "\n");
+        }
+        args.addKeyValuePairsFromPropertyString("-D",properties2,vr,sensitiveVars);
 
         args.addTokenized(targets.replaceAll("[\t\r\n]+"," "));
 
         if(ai!=null)
             ai.buildEnvVars(env);
+        //[cs] replace tab/newlines with spaces to allow antopts to work with expandableTextboxes.
         if(antOpts!=null)
-            env.put("ANT_OPTS",env.expand(antOpts));
+            env.put("ANT_OPTS",env.expand(antOpts.replaceAll("[\t\r\n]+"," ")));
 
         if(!launcher.isUnix()) {
             args = args.toWindowsCommand();


### PR DESCRIPTION
Specifically, the single liner of properties was previously turning into a single variable,
which isn't what was intended by the expandableTextboxes.

Additionally, having mutlilines for ant_opts caused java errors. These just needed
be to collapsed into space separated ant_opts

I just recently these and thought I'd take a shot at fixing them. Please review and let me know if you'd like to see the changes any differently.