### PR TITLE
JENKINS-41801: Allow empty build parameters to be replaced in ant properties

### DIFF
--- a/src/main/java/hudson/tasks/Ant.java
+++ b/src/main/java/hudson/tasks/Ant.java
@@ -65,6 +65,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Properties;
 import java.util.List;
+import java.util.Map;
 import java.util.Collections;
 import java.util.Set;
 
@@ -146,8 +147,17 @@ public class Ant extends Builder {
         ArgumentListBuilder args = new ArgumentListBuilder();
 
         EnvVars env = build.getEnvironment(listener);
-        env.overrideAll(build.getBuildVariables());
-        
+
+        // Allow empty build parameters to be used in property replacements.
+        // The env.override/overrideAll methods remove the propery if it's an empty string.
+        for (Map.Entry<String, String> e : build.getBuildVariables().entrySet()) {
+            if (e.getValue() != null && e.getValue().length() == 0) {
+                env.put(e.getKey(), e.getValue());
+            } else {
+                env.override(e.getKey(), e.getValue());
+            }
+        }
+
         AntInstallation ai = getAnt();
         if(ai==null) {
             args.add(launcher.isUnix() ? "ant" : "ant.bat");


### PR DESCRIPTION
By using EnvVars.overrideAll() to add all build variable to EnvVars, any blank ("") build parameters are not added (or if they existed would be removed) from EnvVars.    This means any reference to a blank variable is not replaced instead of being set to empty.

The tests check the log line where the ant command line is printed.  It's needed to check here for reliable tests, because on unix the $parameter will be replaced by the shell, but not in windows.   By testing the command line params we ensure the replacements occur before going to the OS to run ant.

The tests try to be resilient to the command line and param formatting on windows and non-windows.