### PR TITLE
[FIXED JENKINS-42382] Add PATH+ANT to buildEnvVars(...)

### DIFF
--- a/src/main/java/hudson/tasks/Ant.java
+++ b/src/main/java/hudson/tasks/Ant.java
@@ -375,8 +375,10 @@ public class Ant extends Builder {
             return getHome();
         }
 
+        @Override
         public void buildEnvVars(EnvVars env) {
             env.put("ANT_HOME",getHome());
+            env.put("PATH+ANT", getHome() + "/bin");
         }
 
         /**

--- a/src/test/java/hudson/tasks/AntTest.java
+++ b/src/test/java/hudson/tasks/AntTest.java
@@ -26,6 +26,7 @@ package hudson.tasks;
 import com.gargoylesoftware.htmlunit.html.HtmlButton;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import hudson.EnvVars;
 import hudson.Functions;
 import hudson.matrix.Axis;
 import hudson.matrix.AxisList;
@@ -122,6 +123,12 @@ public class AntTest {
         AntInstallation[] l = r.get(DescriptorImpl.class).getInstallations();
         assertEquals(1,l.length);
         r.assertEqualBeans(l[0],new AntInstallation("myAnt","/tmp/foo", JenkinsRule.NO_PROPERTIES),"name,home");
+
+        // Verify that PATH+ANT is set.
+        EnvVars envVars = new EnvVars();
+        l[0].buildEnvVars(envVars);
+        assertTrue(envVars.containsKey("PATH+ANT"));
+        assertEquals(l[0].getHome() + "/bin", envVars.get("PATH+ANT"));
 
         // by default we should get the auto installer
         DescribableList<ToolProperty<?>,ToolPropertyDescriptor> props = l[0].getProperties();


### PR DESCRIPTION
[JENKINS-42382](https://issues.jenkins-ci.org/browse/JENKINS-42382)

This ensures that Ant's bin directory ends up on the PATH when using
the Pipeline tool step. Note that Jenkins' environment variable
management will handle converting "/bin" on Windows if needed, we do
not need to do that explicitly.

cc @reviewbybees esp @armfergom 