### PR TITLE
[JENKINS-44212] Bump baseline to 1.609

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.17</version>
+    <version>2.28</version>
     <relativePath />
   </parent>
 
@@ -28,10 +28,10 @@
   </scm>
 
   <properties>
-    <jenkins.version>1.596.1</jenkins.version>
+    <jenkins.version>1.609.3</jenkins.version>
     <java.level>6</java.level>
   </properties>
-  
+
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -57,7 +57,7 @@
       </exclusions>
     </dependency>
   </dependencies>
-  
+
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
@@ -79,4 +79,4 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-</project>  
+</project>

--- a/src/test/java/hudson/tasks/AntTest.java
+++ b/src/test/java/hudson/tasks/AntTest.java
@@ -46,6 +46,7 @@ import hudson.model.StringParameterValue;
 import hudson.tasks.Ant.AntInstallation;
 import hudson.tasks.Ant.AntInstallation.DescriptorImpl;
 import hudson.tasks.Ant.AntInstaller;
+import hudson.tasks._ant.AntTargetNote;
 import hudson.tools.InstallSourceProperty;
 import hudson.tools.ToolProperty;
 import hudson.tools.ToolPropertyDescriptor;
@@ -401,6 +402,8 @@ public class AntTest {
         FreeStyleProject project = r.createFreeStyleProject();
         project.setScm(new ExtractResourceSCM(getClass().getResource("sample-helloworld-ant.zip")));
         project.getBuildersList().add(new Ant(targets, antName, ops, buildFile, properties));
+        //Make sure that state is the expected when running secuentially, other tests change this variable
+        AntTargetNote.ENABLED = true;
         return project;
     }
 


### PR DESCRIPTION
[JENKINS-44212](https://issues.jenkins-ci.org/browse/JENKINS-44212)

Due to latest parent pom disabling test concurrency by default a small
change to tests was needed to make it work

@reviewbybees specially @armfergom 