### PR TITLE
[JENKINS-57561] Fix JCasC compatibility issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.42</version>
+    <version>3.48</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.150.1</jenkins.version>
     <java.level>8</java.level>
+    <jcasc.version>1.27</jcasc.version>
   </properties>
 
   <dependencies>
@@ -104,6 +105,20 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
       <version>1.14</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- JCasC compatibility -->
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>${jcasc.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>${jcasc.version}</version>
+      <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/hudson/tasks/Ant.java
+++ b/src/main/java/hudson/tasks/Ant.java
@@ -53,6 +53,7 @@ import hudson.util.VariableResolver;
 import hudson.util.FormValidation;
 import hudson.util.XStream2;
 
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -356,7 +357,9 @@ public class Ant extends Builder {
 
         @DataBoundConstructor
         public AntInstallation(String name, String home, List<? extends ToolProperty<?>> properties) {
-            super(name, launderHome(home), properties);
+            // JENKINS-57561: while ANT_HOME is an empty string when the tool is configured from UI, if that value is not configured in
+            // yaml files for JCasC, home is null causing a NPE
+            super(name, launderHome(StringUtils.defaultString(home)), properties);
         }
 
         /**

--- a/src/test/java/hudson/tasks/AntJCasCCompatibilityTest.java
+++ b/src/test/java/hudson/tasks/AntJCasCCompatibilityTest.java
@@ -32,6 +32,6 @@ public class AntJCasCCompatibilityTest extends RoundTripAbstractTest {
 
     @Override
     protected String stringInLogExpected() {
-        return "Setting class hudson.tools.InstallSourceProperty. installers = [antFromApache]";
+        return "Setting class hudson.tools.InstallSourceProperty. installers = [{antFromApache={}}]";
     }
 }

--- a/src/test/java/hudson/tasks/AntJCasCCompatibilityTest.java
+++ b/src/test/java/hudson/tasks/AntJCasCCompatibilityTest.java
@@ -1,0 +1,37 @@
+package hudson.tasks;
+
+import hudson.tools.InstallSourceProperty;
+import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
+import jenkins.model.Jenkins;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class AntJCasCCompatibilityTest extends RoundTripAbstractTest {
+
+    @Override
+    protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, String s) {
+        final Jenkins jenkins = restartableJenkinsRule.j.jenkins;
+
+        final Ant.DescriptorImpl descriptor = (Ant.DescriptorImpl) jenkins.getDescriptor(Ant.class);
+        assertTrue("The descriptor should not be null", descriptor != null);
+
+        final Ant.AntInstallation[] installations = descriptor.getInstallations();
+        assertEquals("The installation has not retrieved", 2, installations.length);
+
+        Ant.AntInstallation installation = installations[0];
+        assertEquals(String.format("The name should be %s", "Ant 1.10.5"), "Ant 1.10.5", installation.getName());
+        String installerId = installation.getProperties().get(InstallSourceProperty.class).installers.get(Ant.AntInstaller.class).id;
+        assertEquals(String.format("The id for the installer should be %s", "1.10.5"), "1.10.5", installerId);
+
+        installation = installations[1];
+        assertEquals(String.format("The name should be %s", "Ant 1.10.6"), "Ant 1.10.6", installation.getName());
+        assertEquals(String.format("The home path should be %s", "/home/ant"), "/home/ant", installation.getHome());
+    }
+
+    @Override
+    protected String stringInLogExpected() {
+        return "Setting class hudson.tools.InstallSourceProperty. installers = [antFromApache]";
+    }
+}

--- a/src/test/resources/hudson/tasks/configuration-as-code.yaml
+++ b/src/test/resources/hudson/tasks/configuration-as-code.yaml
@@ -1,9 +1,5 @@
 tool:
   ant:
-    defaultProperties:
-      - installSource:
-          installers:
-            - "antFromApache"
     installations:
       - name: "Ant 1.10.5"
         properties:

--- a/src/test/resources/hudson/tasks/configuration-as-code.yaml
+++ b/src/test/resources/hudson/tasks/configuration-as-code.yaml
@@ -1,0 +1,15 @@
+tool:
+  ant:
+    defaultProperties:
+      - installSource:
+          installers:
+            - "antFromApache"
+    installations:
+      - name: "Ant 1.10.5"
+        properties:
+          - installSource:
+              installers:
+                - antFromApache:
+                    id: "1.10.5"
+      - home: "/home/ant"
+        name: "Ant 1.10.6"


### PR DESCRIPTION
See [JENKINS-57561](https://issues.jenkins-ci.org/browse/JENKINS-57561)

Fix the compatibility issue with JCasC. Whilst the field `home` is an empty string when the tool is configured from UI, if that value is not configured in the yaml file for JCasC `home` is null and a NullPointerException is thrown.

This PR also adds a compatibility test.

@oleg-nenashev @varyvol @MRamonLeon @alecharp @rsandell 