### PR TITLE
Docs: Must use script block in declarative

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Or manually:
 
 
 An example of using the Ant task inside Pipeline DSL.
-This code snippet must be put inside a `step` block when using the declarative syntax.
+This code snippet must be put inside a `script` block when using the declarative syntax.
 
 ```groovy
 withAnt(installation: 'myinstall') {


### PR DESCRIPTION
The conditional `if (isUnix())` is not allowed in declarative steps unless surrounded by a `script` block (not a `step` block)