### PR TITLE
Missing `gitHubRepo` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <jenkins.version>2.289.3</jenkins.version>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Forgotten in #93. Cause of failure of https://github.com/jenkinsci/bom/pull/1049.