### PR TITLE
Use explicit imports instead of star to fix deprecation

### DIFF
--- a/src/test/java/hudson/tasks/AntJCasCCompatibilityTest.java
+++ b/src/test/java/hudson/tasks/AntJCasCCompatibilityTest.java
@@ -6,7 +6,7 @@ import jenkins.model.Jenkins;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 
 public class AntJCasCCompatibilityTest extends RoundTripAbstractTest {
 
@@ -15,7 +15,7 @@ public class AntJCasCCompatibilityTest extends RoundTripAbstractTest {
         final Jenkins jenkins = restartableJenkinsRule.j.jenkins;
 
         final Ant.DescriptorImpl descriptor = (Ant.DescriptorImpl) jenkins.getDescriptor(Ant.class);
-        assertTrue("The descriptor should not be null", descriptor != null);
+        assertNotNull("The descriptor should not be null", descriptor);
 
         final Ant.AntInstallation[] installations = descriptor.getInstallations();
         assertEquals("The installation has not retrieved", 2, installations.length);

--- a/src/test/java/hudson/tasks/AntTest.java
+++ b/src/test/java/hudson/tasks/AntTest.java
@@ -60,8 +60,15 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.lang.SystemUtils;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 


### PR DESCRIPTION
Use explicit imports instead of star to fix deprecation and a minor simplification in an assertion.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
