### PR TITLE
Stop managing `commons-lang3`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,11 +35,6 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>3.12.0</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>


### PR DESCRIPTION
No longer needed now that `commons-lang3` is a library plugin.