### PR TITLE
Ban JUnit 4 imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     <jenkins.baseline>2.479</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+    <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>
 
   <dependencyManagement>

--- a/src/test/java/hudson/tasks/AntTest.java
+++ b/src/test/java/hudson/tasks/AntTest.java
@@ -73,7 +73,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.rules.TemporaryFolder;
+
 import org.jvnet.hudson.test.ExtractResourceSCM;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -244,7 +244,7 @@ class AntTest {
     }
 
     private AntInstallation configureDefaultAnt() throws Exception {
-        TemporaryFolder temporaryFolder = new TemporaryFolder(tmp);
+        org.junit.rules.TemporaryFolder temporaryFolder = new org.junit.rules.TemporaryFolder(tmp);
         temporaryFolder.create();
         return ToolInstallations.configureDefaultAnt(temporaryFolder);
     }

--- a/src/test/java/hudson/tasks/AntWrapperTest.java
+++ b/src/test/java/hudson/tasks/AntWrapperTest.java
@@ -41,7 +41,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.*;
 import org.jvnet.hudson.test.junit.jupiter.BuildWatcherExtension;
 import org.jvnet.hudson.test.junit.jupiter.JenkinsSessionExtension;
@@ -59,7 +58,7 @@ class AntWrapperTest {
     @Test
     void configRoundTrip() throws Throwable {
         r.then(j -> {
-            TemporaryFolder temporaryFolder = new TemporaryFolder(tmp);
+            org.junit.rules.TemporaryFolder temporaryFolder = new org.junit.rules.TemporaryFolder(tmp);
             temporaryFolder.create();
             Ant.AntInstallation installation = ToolInstallations.configureDefaultAnt(temporaryFolder);
             FreeStyleProject p = j.createFreeStyleProject(); // no configRoundTrip(BuildWrapper) it seems
@@ -79,7 +78,7 @@ class AntWrapperTest {
     @Test
     void smokes() throws Throwable {
         r.then(j -> {
-            TemporaryFolder temporaryFolder = new TemporaryFolder(tmp);
+            org.junit.rules.TemporaryFolder temporaryFolder = new org.junit.rules.TemporaryFolder(tmp);
             temporaryFolder.create();
             ToolInstallations.configureDefaultAnt(temporaryFolder); // TODO could instead use DockerRule<JavaContainer> to run against a specified JDK location
             DumbSlave s = j.createOnlineSlave();
@@ -101,7 +100,7 @@ class AntWrapperTest {
     @Test
     void durability() throws Throwable {
         r.then(j -> {
-            TemporaryFolder temporaryFolder = new TemporaryFolder(tmp);
+            org.junit.rules.TemporaryFolder temporaryFolder = new org.junit.rules.TemporaryFolder(tmp);
             temporaryFolder.create();
             ToolInstallations.configureDefaultAnt(temporaryFolder);
             WorkflowJob p = j.createProject(WorkflowJob.class, "p");

--- a/src/test/java/hudson/tasks/EnvVarsInConfigTasksTest.java
+++ b/src/test/java/hudson/tasks/EnvVarsInConfigTasksTest.java
@@ -15,7 +15,6 @@ import hudson.tasks.Ant.AntInstallation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.ExtractResourceSCM;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.ToolInstallations;
@@ -47,7 +46,7 @@ class EnvVarsInConfigTasksTest {
         j.jenkins.getJDKs().add(varJDK);
 
         // Ant with a variable in its path
-        TemporaryFolder temporaryFolder = new TemporaryFolder(tmp);
+        org.junit.rules.TemporaryFolder temporaryFolder = new org.junit.rules.TemporaryFolder(tmp);
         temporaryFolder.create();
         AntInstallation ant = ToolInstallations.configureDefaultAnt(temporaryFolder);
         AntInstallation antInstallation =

--- a/src/test/java/hudson/tasks/_ant/AntTargetAnnotationTest.java
+++ b/src/test/java/hudson/tasks/_ant/AntTargetAnnotationTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.SingleFileSCM;
@@ -48,7 +47,7 @@ public class AntTargetAnnotationTest {
     @Test
     void test1() throws Exception {
         FreeStyleProject p = r.createFreeStyleProject();
-        TemporaryFolder temporaryFolder = new TemporaryFolder(tmp);
+        org.junit.rules.TemporaryFolder temporaryFolder = new org.junit.rules.TemporaryFolder(tmp);
         temporaryFolder.create();
         Ant.AntInstallation ant = ToolInstallations.configureDefaultAnt(temporaryFolder);
         p.getBuildersList().add(new Ant("foo",ant.getName(),null,null,null));

--- a/src/test/java/hudson/tools/ToolLocationNodePropertyTest.java
+++ b/src/test/java/hudson/tools/ToolLocationNodePropertyTest.java
@@ -38,7 +38,6 @@ import jenkins.model.Jenkins;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SingleFileSCM;
 import org.jvnet.hudson.test.ToolInstallations;
@@ -83,7 +82,7 @@ class ToolLocationNodePropertyTest {
 
     @Test
     void ant() throws Exception {
-        TemporaryFolder temporaryFolder = new TemporaryFolder(tmp);
+        org.junit.rules.TemporaryFolder temporaryFolder = new org.junit.rules.TemporaryFolder(tmp);
         temporaryFolder.create();
         AntInstallation ant = ToolInstallations.configureDefaultAnt(temporaryFolder);
         String antPath = ant.getHome();


### PR DESCRIPTION
### Ban JUnit 4 imports

To prevent regressions when adding new tests, https://github.com/jenkinsci/plugin-pom/pull/1178 introduced a new flag that enables a Maven Enforcer rule banning `org.junit.*` imports while allowing `org.junit.jupiter.*`.

With this change, the build will fail if any `org.junit.*` imports are introduced.

### Testing done

None. Rely on `ci.jenkins.io`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed